### PR TITLE
Add debian/python3-libpam-fingerprint.install

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Clone this repository
 
 Build the package
 
-    ~$ cd ./pam-fingerprint/src/
+    ~$ cd ./pam-fingerprint
     ~$ sudo mk-build-deps -i debian/control
     ~$ dpkg-buildpackage -uc -us
 

--- a/debian/python3-libpam-fingerprint.install
+++ b/debian/python3-libpam-fingerprint.install
@@ -1,0 +1,4 @@
+debian/pam-auth-update/fingerprint usr/share/pam-configs/
+src/pam_fingerprint.py lib/security/
+src/pamfingerprint-conf usr/bin/
+src/pamfingerprint.conf etc/


### PR DESCRIPTION
A trial pull request; 
I wonder it might be caused by debhelper or pybuild version , or linux distribution.  If you have better solution, please tell me and close this PR.

## problem
- My environment
    - Debian12 (bookworm)
    - using system python3 (3.11)

On my environment, after exec `dpkg-buildpackage -uc -us` , deb package doesn't contain python sources.
I notice it because after installed `libpam-fingerprint_1.6_all.deb` , pamfingerprint-conf is not found.

## solution
- After added `debian/python3-libpam-fingerprint.install` in source tree,  exec `dpkg-buildpackage -uc -us` , and I could get a complete package containing all python sources.


```shell
dpkg-deb -c ../libpam-fingerprint_1.6_all.deb 
drwxr-xr-x root/root         0 2023-07-03 04:25 ./
drwxr-xr-x root/root         0 2023-07-03 04:25 ./etc/
-rw-r--r-- root/root       277 2023-07-03 04:25 ./etc/pamfingerprint.conf
drwxr-xr-x root/root         0 2023-07-03 04:25 ./lib/
drwxr-xr-x root/root         0 2023-07-03 04:25 ./lib/security/
-rw-r--r-- root/root      7343 2023-07-03 04:25 ./lib/security/pam_fingerprint.py
drwxr-xr-x root/root         0 2023-07-03 04:25 ./usr/
drwxr-xr-x root/root         0 2023-07-03 04:25 ./usr/bin/
-rwxr-xr-x root/root     12031 2023-07-03 04:25 ./usr/bin/pamfingerprint-conf
drwxr-xr-x root/root         0 2023-07-03 04:25 ./usr/lib/
drwxr-xr-x root/root         0 2023-07-03 04:25 ./usr/lib/python3/
drwxr-xr-x root/root         0 2023-07-03 04:25 ./usr/lib/python3/dist-packages/
drwxr-xr-x root/root         0 2023-07-03 04:25 ./usr/lib/python3/dist-packages/libpam_fingerprint-1.6.egg-info/
-rw-r--r-- root/root       498 2023-07-03 04:25 ./usr/lib/python3/dist-packages/libpam_fingerprint-1.6.egg-info/PKG-INFO
-rw-r--r-- root/root         1 2023-07-03 04:25 ./usr/lib/python3/dist-packages/libpam_fingerprint-1.6.egg-info/dependency_links.txt
-rw-r--r-- root/root         0 2023-07-03 04:25 ./usr/lib/python3/dist-packages/libpam_fingerprint-1.6.egg-info/requires.txt
-rw-r--r-- root/root        15 2023-07-03 04:25 ./usr/lib/python3/dist-packages/libpam_fingerprint-1.6.egg-info/top_level.txt
drwxr-xr-x root/root         0 2023-07-03 04:25 ./usr/lib/python3/dist-packages/pamfingerprint/
-rw-r--r-- root/root       273 2023-07-03 04:25 ./usr/lib/python3/dist-packages/pamfingerprint/__init__.py
drwxr-xr-x root/root         0 2023-07-03 04:25 ./usr/share/
drwxr-xr-x root/root         0 2023-07-03 04:25 ./usr/share/bash-completion/
drwxr-xr-x root/root         0 2023-07-03 04:25 ./usr/share/bash-completion/completions/
-rw-r--r-- root/root       425 2023-07-03 04:25 ./usr/share/bash-completion/completions/pamfingerprint
drwxr-xr-x root/root         0 2023-07-03 04:25 ./usr/share/doc/
drwxr-xr-x root/root         0 2023-07-03 04:25 ./usr/share/doc/libpam-fingerprint/
-rw-r--r-- root/root       537 2023-07-03 04:25 ./usr/share/doc/libpam-fingerprint/changelog.gz
-rw-r--r-- root/root      1029 2023-07-03 04:25 ./usr/share/doc/libpam-fingerprint/copyright
drwxr-xr-x root/root         0 2023-07-03 04:25 ./usr/share/lintian/
drwxr-xr-x root/root         0 2023-07-03 04:25 ./usr/share/lintian/overrides/
-rw-r--r-- root/root       132 2023-07-03 04:25 ./usr/share/lintian/overrides/libpam-fingerprint
drwxr-xr-x root/root         0 2023-07-03 04:25 ./usr/share/man/
drwxr-xr-x root/root         0 2023-07-03 04:25 ./usr/share/man/man1/
-rw-r--r-- root/root       538 2023-07-03 04:25 ./usr/share/man/man1/pamfingerprint-conf.1.gz
drwxr-xr-x root/root         0 2023-07-03 04:25 ./usr/share/pam-configs/
-rw-r--r-- root/root       132 2023-07-03 04:25 ./usr/share/pam-configs/fingerprint
```